### PR TITLE
feat(api): Show link if redirect fails

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -53,7 +53,13 @@ function parseRequestParameters() {
  * This is needed because we can't respond with HTTP redirect codes.
  */
 function generateRedirectPage(url: string) {
-  return `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=${url}"></head></html>`;
+  return (
+    '<!DOCTYPE html>' +
+    '<html>' +
+    `<head><meta http-equiv="refresh" content="0;url=${url}"></head>` +
+    `<body>If your browser does not redirect you immediately, <a href="${url}">click here</a></body>` +
+    '</html>'
+  );
 }
 
 export function main() {

--- a/release/relay/relay_Philter_Manager.js
+++ b/release/relay/relay_Philter_Manager.js
@@ -1605,7 +1605,11 @@ function parseRequestParameters() {
  * This is needed because we can't respond with HTTP redirect codes.
  */
 function generateRedirectPage(url) {
-    return "<!DOCTYPE html><html><head><meta http-equiv=\"refresh\" content=\"0;url=" + url + "\"></head></html>";
+    return ('<!DOCTYPE html>' +
+        '<html>' +
+        ("<head><meta http-equiv=\"refresh\" content=\"0;url=" + url + "\"></head>") +
+        ("<body>If your browser does not redirect you immediately, <a href=\"" + url + "\">click here</a></body>") +
+        '</html>');
 }
 function main() {
     // TODO: Add require() to kolmafia-types if possible


### PR DESCRIPTION
Some users may disable redirects via `http-equiv="refresh"`. In this case, we show a clickable link to the redirect URL.

This closes #62. Thanks to @midgleyc who submitted the original PR.