### PR TITLE
fix(manager): Don't inject invalid env var names

### DIFF
--- a/packages/manager/vite.config.ts
+++ b/packages/manager/vite.config.ts
@@ -45,10 +45,11 @@ export default defineConfig({
     sourcemap: true,
   },
   define: Object.fromEntries(
-    Object.entries(process.env).map(([name, value]) => [
-      `process.env.${name}`,
-      JSON.stringify(value),
-    ])
+    Object.entries(process.env)
+      // Exclude environment variables that are not valid JavaScript identifiers
+      // (we ignore names with non-ASCII characters for practical purposes)
+      .filter(([name]) => /[_$a-zA-Z][_$\w]*$/.test(name))
+      .map(([name, value]) => [`process.env.${name}`, JSON.stringify(value)])
   ),
   plugins: [reactRefresh()],
   server: {


### PR DESCRIPTION
Some development environments (e.g. Windows 10) inject environment variables with weird names, such as `ProgramFiles(x86)`. Such variables cannot be injected as `process.env.<env_var>` during build. This causes Vite to fail when attempting to launch the dev server (`yarn workspace @philter/manager run dev`).

This PR fixes the problem by filtering any environment variables whose names contain invalid characters.

This fixes an issue during development; it does not affect users.