### PR TITLE
build: use TypeScript for all Rollup configs

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup --configPlugin typescript -c rollup.config.ts",
     "clean": "rimraf build .rollup.cache",
     "fix": "eslint --fix .",
     "lint": "eslint .",
@@ -27,7 +27,7 @@
     "buble-config-rhino": "^0.1.0",
     "gts": "^3.1.0",
     "rimraf": "^3.0.2",
-    "rollup": "^2.51.2",
+    "rollup": "^2.52.0",
     "rollup-plugin-copy": "^3.4.0",
     "tslib": "^2.3.0",
     "typescript": "^4.3.2"

--- a/packages/api/rollup.config.ts
+++ b/packages/api/rollup.config.ts
@@ -33,19 +33,18 @@
  */
 
 /* eslint-disable node/no-unpublished-import */
-/* eslint-disable node/no-unsupported-features/es-syntax */
-// Import @philter/common using a relative path. This is a hack, btw.
-// File extension is required to make this work in Node.js v12 AND v14.
 import buble from '@rollup/plugin-buble';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import createPreset from 'buble-config-rhino';
+import type {RollupOptions} from 'rollup';
 import copy from 'rollup-plugin-copy';
+// Import @philter/common using a relative path. This is a hack, btw.
+// File extension is required to make this work in Node.js v12 AND v14.
 // eslint-disable-next-line node/no-missing-import
 import {RELAY_SCRIPT_FILE} from '../common/build/src/index.js';
 
-/** @type {import('rollup').RollupOptions} */
-const config = {
+const config: RollupOptions = {
   external: ['kolmafia', 'philter.util.ash', 'zlib.ash'],
   input: 'src/index.ts',
   output: {

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -2,8 +2,11 @@
 // Currently, this is used only to type-check the Rollup config in the editor.
 {
   "extends": "gts/tsconfig-google.json",
-  // Don't try to actually compile anything with this
-  // (may change if we add custom build/maintenance scripts)
-  "files": [],
+  "compilerOptions": {
+    // Override setting set by GTS's tsconfig to make @rollup/plugin-typescript
+    // happy
+    "declaration": false
+  },
+  "files": ["rollup.config.ts"],
   "references": [{"path": "../common"}]
 }

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -8,7 +8,7 @@
   "author": "Yehyoung Kang",
   "main": "index.js",
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup --configPlugin typescript -c rollup.config.ts",
     "clean": "gts clean",
     "compile": "tsc -b",
     "fix": "eslint --fix .",
@@ -37,7 +37,7 @@
     "@rollup/plugin-typescript": "^8.2.1",
     "buble-config-rhino": "^0.1.0",
     "gts": "^3.1.0",
-    "rollup": "^2.51.2",
+    "rollup": "^2.52.0",
     "tslib": "^2.3.0",
     "typescript": "^4.3.2"
   }

--- a/packages/e2e-tests/rollup.config.ts
+++ b/packages/e2e-tests/rollup.config.ts
@@ -1,13 +1,12 @@
 /* eslint-disable node/no-unpublished-import */
-/* eslint-disable node/no-unsupported-features/es-syntax */
+import buble from '@rollup/plugin-buble';
 import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
-import buble from '@rollup/plugin-buble';
 import createPreset from 'buble-config-rhino';
+import type {RollupOptions} from 'rollup';
 
-/** @type {import("rollup").RollupOptions} */
-const config = {
+const config: RollupOptions = {
   external: ['kolmafia', 'philter.util.ash', 'zlib.ash'],
   input: 'src/ocd-test-basic.ts',
   output: {

--- a/packages/e2e-tests/tsconfig.json
+++ b/packages/e2e-tests/tsconfig.json
@@ -3,12 +3,11 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "checkJs": true,
     "noEmit": true,
     // Don't include any @types/* packages, which may otherwise pull in unwanted
     // libs (e.g. "lib.es2017.object.d.ts")
     "types": []
   },
-  "files": ["rollup.config.js"],
+  "files": ["rollup.config.ts"],
   "references": [{"path": "src"}]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2923,7 +2923,7 @@ rollup-plugin-copy@^3.4.0:
     globby "10.0.1"
     is-plain-object "^3.0.0"
 
-rollup@^2.38.5, rollup@^2.51.2, rollup@^2.53.3:
+rollup@^2.38.5, rollup@^2.52.0, rollup@^2.53.3:
   version "2.53.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.53.3.tgz#14b0e57f0874d4ad23bdbb13050cf70bcd1eabf7"
   integrity sha512-79QIGP5DXz5ZHYnCPi3tLz+elOQi6gudp9YINdaJdjG0Yddubo6JRFUM//qCZ0Bap/GJrsUoEBVdSOc4AkMlRA==


### PR DESCRIPTION
This commit updates all Rollup configs to use TypeScript, thanks to Rollup 2.52.0+ which supports config files written in TS. Also changes some `tsconfig.json` files to work with the new TS-based configs.

This change affects the build process only.