### PR TITLE
chore(manager): launch browser on `dev`/`serve`

### DIFF
--- a/packages/manager/vite.config.ts
+++ b/packages/manager/vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
   ),
   plugins: [reactRefresh()],
   server: {
+    open: '/philter-manager.index.html',
     proxy: {
       // Typical port for KoLmafia's relay browser
       '^/(relay_|images)': 'http://localhost:60080',


### PR DESCRIPTION
Make Vite automatically launch Philter Manager in the system web browser when running `vite dev` or `vite serve` commands.